### PR TITLE
Feature/4 agents should see some global states of the last seen adversary agent

### DIFF
--- a/src/main/kotlin/org/openbase/planetsudo/game/GameSound.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/GameSound.kt
@@ -77,6 +77,7 @@ enum class GameSound(uri: String) {
             return
         }
 
+        println("Play sound: ${this.name}")
         AUDIO_SERVER.playAudio(audioData)
         soundHistory[this] = Instant.now()
     }

--- a/src/main/kotlin/org/openbase/planetsudo/game/strategy/AbstractStrategy.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/strategy/AbstractStrategy.kt
@@ -8,10 +8,7 @@ import org.openbase.planetsudo.game.GameManager
 import org.openbase.planetsudo.game.SwatTeam
 import org.openbase.planetsudo.game.SwatTeam.*
 import org.openbase.planetsudo.level.AbstractLevel
-import org.openbase.planetsudo.level.levelobjects.Agent
-import org.openbase.planetsudo.level.levelobjects.AgentInterface
-import org.openbase.planetsudo.level.levelobjects.Mothership
-import org.openbase.planetsudo.level.levelobjects.MothershipInterface
+import org.openbase.planetsudo.level.levelobjects.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.beans.PropertyChangeEvent
@@ -26,6 +23,7 @@ abstract class AbstractStrategy(val agent: AgentInterface) : Runnable {
 
     private val strategyOwner: Agent by lazy { agent as Agent }
     val mothership: MothershipInterface by lazy { strategyOwner.mothership }
+    val adversaryAgent: GlobalAgentInterface get() = agent.adversaryAgent
     val mothershipInternal: Mothership by lazy { strategyOwner.mothership }
     private val rules: TreeMap<Int, Rule> = TreeMap()
     private val gameManager: GameManager = GameManager.gameManager

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
@@ -50,7 +50,7 @@ class Agent(
         protected set
     override var fuel: Int = 0
         protected set
-    override var tonic: Int = 0
+    override var tonic: Int = 3
         protected set
 
     var shiftTonic: Double = 0.0
@@ -75,6 +75,8 @@ class Agent(
     override var isGameOverSoon: Boolean
         private set
     private val swatTeamSet: MutableSet<SwatTeam>
+
+    private var lastAversaryAgent: Agent? = null
 
     override val angle: Int
         get() = direction.angle
@@ -362,6 +364,17 @@ class Agent(
         }
     }
 
+    override fun turnToAdversaryAgent(beta: Int) {
+        ap.actionPoint
+        if (useFuel()) {
+            val adversaryAgent = level.getAdversaryAgent(this)
+            if (adversaryAgent != null) {
+                direction.turnTo(position, adversaryAgent.position)
+                direction.angle += beta
+            }
+        }
+    }
+
     override fun turnRandom() {
         turnRandom(360)
     }
@@ -508,7 +521,8 @@ class Agent(
     }
 
     override fun seeAdversaryAgent(): Boolean {
-        return level.getAdversaryAgent(this) != null
+        lastAversaryAgent = level.getAdversaryAgent(this)
+        return lastAversaryAgent != null
     }
 
     override fun seeTeamAgent(): Boolean {
@@ -805,6 +819,12 @@ class Agent(
             GameSound.Shift.play()
         }
     }
+
+    override val adversaryAgent: GlobalAgentInterface
+        get() = GlobalAgentProxy(
+            lastAversaryAgent
+                ?: error("No adversary agent seen!"),
+        ) ?: error("No adversary agent seen!")
 
     companion object {
         // 	public final static int DEFAULT_START_FUEL = 2000;

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
@@ -786,7 +786,7 @@ class Agent(
 
     override fun makeInvisible() {
         ap.getActionPoint(100)
-        if (hasTonicForInvisibility()) {
+        if (hasTonicForInvisibility) {
             tonic = 0
             invisible = true
         }

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentInterface.kt
@@ -45,7 +45,76 @@ import org.openbase.planetsudo.level.levelobjects.Tower.TowerType
  *
  * @author Divine Threepwood
  */
-interface AgentInterface {
+interface AgentInterface : GlobalAgentInterface {
+
+    /**
+     * Gibt an, ob ein Zusammensto mit einer Wand bevorsteht.
+     *
+     * @return true oder false.
+     */
+    val isCollisionDetected: Boolean
+
+    /**
+     * Gibt zurück, ob der Agent Bewegungsunfähig ist. (Zerstört
+     * oder ohne Treibstoff)
+     *
+     * @return true oder false.
+     */
+    val isDisabled: Boolean
+
+    /**
+     * Abfrage, ob der Agent aktuell unsichtbar ist.
+     */
+    val isInvisible: Boolean
+
+    /**
+     * Abfrage, ob der Agent aktuell sichtbar ist.
+     */
+    val isVisible: Boolean get() = !isInvisible
+
+    /**
+     * Diese Abfrage checkt das bevorstehende Ende des Spiels. Wenn es bald
+     * vorbei ist, gibt sie true zurück, dann sollte man schleunigst zum
+     * Mutterschiff.
+     *
+     * @return true oder false
+     */
+    val isGameOverSoon: Boolean
+
+    /**
+     * Gibt zurück, ob der Agent eine Resource berührt und diese somit
+     * aufgeben kann.
+     *
+     * @return true oder false.
+     */
+    val isTouchingResource: Boolean
+
+    /**
+     * Gibt die Punkte des Teams wieder.
+     *
+     * @return Den Punktestand als ganze Zahl (z.B. 47)
+     */
+    val teamPoints: Int
+
+    /**
+     * Gibt an, ob der Agent noch lebt.
+     *
+     * @return true oder false.
+     */
+    val isAlive: Boolean
+
+    /**
+     * Gibt zurück, ob der Agent beim Mutterschiff ist.
+     *
+     * @return true oder false.
+     */
+    val isAtMothership: Boolean
+
+    /**
+     * Liefert Informationen über einen feindlichen Agenten in der Nähe.
+     */
+    val adversaryAgent: GlobalAgentInterface
+
     /**
      * Der angeforderte Support des Agenten wird beendet.
      * Treibstoff: 1
@@ -89,86 +158,6 @@ interface AgentInterface {
      * Treibstoff: 1
      */
     fun fightWithAdversaryMothership()
-
-    /**
-     * Gibt die verfügbaren Aktionspunkte wieder.
-     *
-     * @return Die Aktionspunkte als ganze Zahl. (z.B. 2051)
-     */
-    val actionPoints: Int
-
-    /**
-     * Gibt die Richtung des Agenten in Grad wieder. Rechts = 0° Runter = 90°
-     * Links = 180° Hoch = 270°
-     *
-     * @return Den Winkel von 0 - 360° als ganze Zahl. (z.B. 128)
-     */
-    val angle: Int
-
-    /**
-     * Zeigt den verbliebenen Treibstoff des Agenten an.
-     *
-     * @return Den verbliebenen Treibstoff als ganz Zahl.
-     */
-    val fuel: Int
-
-    /**
-     * Zeigt den aktuellen Tonic Bestand des Agenten an.
-     *
-     * 0 = Kein Tonic
-     * 1 = Reicht für einen Shift
-     * 2 = Reicht für zwei Shifts
-     * 3 = Reicht für drei Shifts oder ermöglicht es den Agenten unsichtbar zu machen.
-     *
-     * @return Die aktuelle Tonic Menge als ganz Zahl zwischen 0 - 3.
-     */
-    val tonic: Int
-
-    /**
-     * Zeigt den aktuellen Tonic Bestand des Agenten in Prozent.
-     *
-     *   0 % = Kein Tonic
-     *  33 % = Reicht für einen Shift
-     *  66 % = Reicht für zwei Shifts
-     * 100 % = Reicht für drei Shifts oder ermöglicht es den Agenten unsichtbar zu machen.
-     *
-     * @return Die aktuelle Tonic Menge als ganz Zahl zwischen 0 - 100.
-     */
-    val tonicInPercent: Int
-
-    /**
-     *  Gibt an, ob der Agent die maximale Anzahl an Tonic besitzt und somit genug Tonic hat um sich unsichtbar zu machen.
-     */
-    val tonicFull: Boolean get() = tonic == Agent.MAX_TONIC
-
-    /**
-     * Gibt den verbliebenen Treibstoff in Prozent an.
-     *
-     * @return Treibstoffwert in Prozent als ganze Zahl. (z.B. 47 bei 47%
-     * verbliebenen Treibstoff)
-     */
-    val fuelInPercent: Int
-
-    /**
-     * Gibt das Maximalvolumen vom Treibstoff eines Agenten an.
-     *
-     * @return
-     */
-    val fuelVolume: Int
-
-    /**
-     * Gibt den Typ der Resource wieder, welche der Agent berührt.
-     *
-     * @return Den Ressourcenwert
-     */
-    val resourceType: ResourceType?
-
-    /**
-     * Gibt die Punkte des Teams wieder.
-     *
-     * @return Den Punktestand als ganze Zahl (z.B. 47)
-     */
-    val teamPoints: Int
 
     /**
      * Der Agent bewegt sich geradeaus.
@@ -264,158 +253,11 @@ interface AgentInterface {
     fun goToAdversaryAgent()
 
     /**
-     * Gibt zurück, ob der Agent Treibstoff hat.
-     *
-     * @return true oder false.
-     */
-    fun hasFuel(): Boolean
-
-    /**
-     * Gibt zurück, ob der Agent mindestens ein Tonic besitzt.
-     *
-     * @return true oder false.
-     */
-    fun hasTonic(): Boolean = tonic >= 1
-
-    /**
-     * Gibt zurück, ob der Agent genug Tonic besitzt, um sich unsichtbar zu machen.
-     *
-     * @return true oder false.
-     */
-    fun hasTonicForInvisibility(): Boolean = tonic == Agent.MAX_TONIC
-
-    /**
      * Gibt zurück, ob der Agent seine Mine noch trägt.
      *
      * @return true oder false.
      */
     fun hasMine(): Boolean
-
-    /**
-     * Gibt an, ob der Agent noch lebt.
-     *
-     * @return true oder false.
-     */
-    val isAlive: Boolean
-
-    /**
-     * Gibt zurück, ob der Agent beim Mutterschiff ist.
-     *
-     * @return true oder false.
-     */
-    val isAtMothership: Boolean
-
-    /**
-     * Zeigt an, ob der Agent eine Resource trägt.
-     *
-     * @return true oder false
-     */
-    val isCarryingResource: Boolean
-
-    /**
-     * Gibt an, ob der Agent eine Resource vom `type` trägt.
-     *
-     * @param type
-     * @return true oder false.
-     */
-    fun isCarryingResource(type: ResourceType): Boolean
-
-    /**
-     * Zeigt an, ob der Agent eine Resource trägt.
-     *
-     * @return true oder false
-     */
-    @Deprecated("Typo fixed", replaceWith = ReplaceWith("isCarryingResource"))
-    val isCarringResource: Boolean get() = isCarryingResource
-
-    /**
-     * Gibt an, ob der Agent eine Resource vom `type` trägt.
-     *
-     * @param type
-     * @return true oder false.
-     */
-    @Deprecated("Typo fixed", replaceWith = ReplaceWith("isCarryingResource"))
-    fun isCarringResource(type: ResourceType): Boolean = isCarryingResource(type)
-
-    /**
-     * Gibt an, ob ein Zusammensto mit einer Wand bevorsteht.
-     *
-     * @return true oder false.
-     */
-    val isCollisionDetected: Boolean
-
-    /**
-     * Gibt zurück, ob der Agent ein Commander ist oder nicht.
-     *
-     * @return true oder false
-     */
-    val isCommander: Boolean
-
-    /**
-     * Gibt zurück, ob der Agent Bewegungsunfähig ist. (Zerstört
-     * oder ohne Treibstoff)
-     *
-     * @return true oder false.
-     */
-    val isDisabled: Boolean
-
-    /**
-     * Abfrage, ob der Agent sich im Kampf befindet oder nicht.
-     *
-     * @return true oder false.
-     */
-    val isFighting: Boolean
-
-    /**
-     * Abfrage, ob der Agent aktuell unsichtbar ist.
-     */
-    val isInvisible: Boolean
-
-    /**
-     * Abfrage, ob der Agent aktuell sichtbar ist.
-     */
-    val isVisible: Boolean get() = !isInvisible
-
-    /**
-     * Abfrage, ob dieser agent Support angefordert hat!
-     * !!! Nicht ob irgend einer Support angefordert hat!!!
-     * Hierfür mothership.needSomeoneSupport(); benutzen.
-     *
-     * @return true oder false
-     */
-    val isSupportOrdered: Boolean
-
-    /**
-     * Diese Abfrage checkt das bevorstehende Ende des Spiels. Wenn es bald
-     * vorbei ist, gibt sie true zurück, dann sollte man schleunigst zum
-     * Mutterschiff.
-     *
-     * @return true oder false
-     */
-    val isGameOverSoon: Boolean
-
-    /**
-     * Gibt zurück, ob der Agent eine Resource berührt und diese somit
-     * aufgeben kann.
-     *
-     * @return true oder false.
-     */
-    val isTouchingResource: Boolean
-
-    /**
-     * Gibt zurück, ob der Agent eine Resource vom Typ `type` berührt und diese somit aufgeben kann.
-     *
-     * @param type
-     * @return
-     */
-    fun isTouchingResource(type: ResourceType): Boolean
-
-    /**
-     * Gibt an, ob der Agent unter Beschuss steht.
-     *
-     * @return true oder false.
-     */
-    val isUnderAttack: Boolean
 
     /**
      * Der Agent fordert `percent` Prozent Treibstoff vom Mutterschiff an.
@@ -566,9 +408,7 @@ interface AgentInterface {
     fun turnRandom(opening: Int)
 
     /**
-     * Der Agent dreht sich um Winkel {
-     *
-     * `beta`° nach rechts.
+     * Der Agent dreht sich um Winkel `beta`° nach rechts.
      *
      * @param beta Gewünschter Winkel in Grad (0 - 360)
      * Aktionspunkte: 1
@@ -584,6 +424,17 @@ interface AgentInterface {
      * Treibstoff: 1
      */
     fun turnToResource()
+
+    /**
+     * Der Agent dreht sich zu einem feindlichen Agenten in Sichtweite.
+     * Falls kein feindlicher Agent in der Nähe ist, kostet diese Aktion nur APs.
+     *
+     * Optional kann ein Winkel `beta`° angegeben werden, um den Agenten zusätzlich weiter rechts rum zu drehen.
+     *
+     * Aktionspunkte: 1
+     * Treibstoff: 1
+     */
+    fun turnToAdversaryAgent(beta: Int = 0)
 
     /**
      * Der Agent dreht sich zu einer nahen Resource eines bestimmten Typs.
@@ -652,9 +503,4 @@ interface AgentInterface {
      * Tonic: 1
      */
     fun shift()
-
-    /**
-     * Gibt zurück, ob der Agent gerade shifted.
-     */
-    fun isShifting(): Boolean
 }

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentMock.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentMock.kt
@@ -94,6 +94,8 @@ class AgentMock : AgentInterface {
         get() = error("Mock does not offer any functionality.")
     override val isAtMothership: Boolean
         get() = error("Mock does not offer any functionality.")
+    override val adversaryAgent: GlobalAgentInterface
+        get() = error("Mock does not offer any functionality.")
     override val isCarryingResource: Boolean
         get() = error("Mock does not offer any functionality.")
 
@@ -210,6 +212,10 @@ class AgentMock : AgentInterface {
     }
 
     override fun turnToResource(resourceType: Resource.ResourceType) {
+        error("Mock does not offer any functionality.")
+    }
+
+    override fun turnToAdversaryAgent(beta: Int) {
         error("Mock does not offer any functionality.")
     }
 

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentInterface.kt
@@ -150,7 +150,8 @@ interface GlobalAgentInterface {
      *
      * @return true oder false.
      */
-    fun hasTonicForInvisibility(): Boolean = tonic == Agent.MAX_TONIC
+    val hasTonicForInvisibility: Boolean
+        get() = tonic == Agent.MAX_TONIC
 
     /**
      * Gibt an, ob der Agent eine Resource vom `type` trägt.

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentInterface.kt
@@ -1,0 +1,173 @@
+package org.openbase.planetsudo.level.levelobjects
+
+interface GlobalAgentInterface {
+
+    /**
+     * Gibt zurück, ob der Agent ein Commander ist oder nicht.
+     *
+     * @return true oder false
+     */
+    val isCommander: Boolean
+
+    /**
+     * Abfrage, ob der Agent sich im Kampf befindet oder nicht.
+     *
+     * @return true oder false.
+     */
+    val isFighting: Boolean
+
+    /**
+     * Abfrage, ob dieser agent Support angefordert hat!
+     * !!! Nicht ob irgend einer Support angefordert hat!!!
+     * Hierfür mothership.needSomeoneSupport(); benutzen.
+     *
+     * @return true oder false
+     */
+    val isSupportOrdered: Boolean
+
+    /**
+     * Gibt an, ob der Agent unter Beschuss steht.
+     *
+     * @return true oder false.
+     */
+    val isUnderAttack: Boolean
+
+    /**
+     * Gibt die verfügbaren Aktionspunkte wieder.
+     *
+     * @return Die Aktionspunkte als ganze Zahl. (z.B. 2051)
+     */
+    val actionPoints: Int
+
+    /**
+     * Gibt die Richtung des Agenten in Grad wieder. Rechts = 0° Runter = 90°
+     * Links = 180° Hoch = 270°
+     *
+     * @return Den Winkel von 0 - 360° als ganze Zahl. (z.B. 128)
+     */
+    val angle: Int
+
+    /**
+     * Zeigt den verbliebenen Treibstoff des Agenten an.
+     *
+     * @return Den verbliebenen Treibstoff als ganz Zahl.
+     */
+    val fuel: Int
+
+    /**
+     * Zeigt den aktuellen Tonic Bestand des Agenten an.
+     *
+     * 0 = Kein Tonic
+     * 1 = Reicht für einen Shift
+     * 2 = Reicht für zwei Shifts
+     * 3 = Reicht für drei Shifts oder ermöglicht es den Agenten unsichtbar zu machen.
+     *
+     * @return Die aktuelle Tonic Menge als ganz Zahl zwischen 0 - 3.
+     */
+    val tonic: Int
+
+    /**
+     * Zeigt den aktuellen Tonic Bestand des Agenten in Prozent.
+     *
+     *   0 % = Kein Tonic
+     *  33 % = Reicht für einen Shift
+     *  66 % = Reicht für zwei Shifts
+     * 100 % = Reicht für drei Shifts oder ermöglicht es den Agenten unsichtbar zu machen.
+     *
+     * @return Die aktuelle Tonic Menge als ganz Zahl zwischen 0 - 100.
+     */
+    val tonicInPercent: Int
+
+    /**
+     *  Gibt an, ob der Agent die maximale Anzahl an Tonic besitzt und somit genug Tonic hat um sich unsichtbar zu machen.
+     */
+    val tonicFull: Boolean get() = tonic == Agent.MAX_TONIC
+
+    /**
+     * Gibt den verbliebenen Treibstoff in Prozent an.
+     *
+     * @return Treibstoffwert in Prozent als ganze Zahl. (z.B. 47 bei 47%
+     * verbliebenen Treibstoff)
+     */
+    val fuelInPercent: Int
+
+    /**
+     * Gibt das Maximalvolumen vom Treibstoff eines Agenten an.
+     *
+     * @return
+     */
+    val fuelVolume: Int
+
+    /**
+     * Gibt den Typ der Resource wieder, welche der Agent berührt.
+     *
+     * @return Den Ressourcenwert
+     */
+    val resourceType: Resource.ResourceType
+
+    /**
+     * Zeigt an, ob der Agent eine Resource trägt.
+     *
+     * @return true oder false
+     */
+    val isCarryingResource: Boolean
+
+    /**
+     * Gibt zurück, ob der Agent Treibstoff hat.
+     *
+     * @return true oder false.
+     */
+    fun hasFuel(): Boolean
+
+    /**
+     * Gibt zurück, ob der Agent mindestens ein Tonic besitzt.
+     *
+     * @return true oder false.
+     */
+    fun hasTonic(): Boolean = tonic >= 1
+
+    /**
+     * Gibt zurück, ob der Agent genug Tonic besitzt, um sich unsichtbar zu machen.
+     *
+     * @return true oder false.
+     */
+    fun hasTonicForInvisibility(): Boolean = tonic == Agent.MAX_TONIC
+
+    /**
+     * Gibt an, ob der Agent eine Resource vom `type` trägt.
+     *
+     * @param type
+     * @return true oder false.
+     */
+    fun isCarryingResource(type: Resource.ResourceType): Boolean
+
+    /**
+     * Zeigt an, ob der Agent eine Resource trägt.
+     *
+     * @return true oder false
+     */
+    @Deprecated("Typo fixed", replaceWith = ReplaceWith("isCarryingResource"))
+    val isCarringResource: Boolean get() = isCarryingResource
+
+    /**
+     * Gibt an, ob der Agent eine Resource vom `type` trägt.
+     *
+     * @param type
+     * @return true oder false.
+     */
+    @Deprecated("Typo fixed", replaceWith = ReplaceWith("isCarryingResource"))
+    fun isCarringResource(type: Resource.ResourceType): Boolean = isCarryingResource(type)
+
+    /**
+     * Gibt zurück, ob der Agent eine Resource vom Typ `type` berührt und diese somit aufheben kann.
+     *
+     * @param type
+     * @return true oder false.
+     */
+    fun isTouchingResource(type: Resource.ResourceType): Boolean
+
+    /**
+     * Gibt zurück, ob der Agent gerade shifted.
+     */
+    fun isShifting(): Boolean
+}

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentProxy.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/GlobalAgentProxy.kt
@@ -1,0 +1,35 @@
+package org.openbase.planetsudo.level.levelobjects
+
+class GlobalAgentProxy(val agent: AgentInterface) : GlobalAgentInterface {
+    override val isCommander: Boolean
+        get() = agent.isCommander
+    override val isFighting: Boolean
+        get() = agent.isFighting
+    override val isSupportOrdered: Boolean
+        get() = agent.isSupportOrdered
+    override val isUnderAttack: Boolean
+        get() = agent.isUnderAttack
+    override val actionPoints: Int
+        get() = agent.actionPoints
+    override val angle: Int
+        get() = agent.angle
+    override val fuel: Int
+        get() = agent.fuel
+    override val tonic: Int
+        get() = agent.tonic
+    override val tonicInPercent: Int
+        get() = agent.tonicInPercent
+    override val fuelInPercent: Int
+        get() = agent.fuelInPercent
+    override val fuelVolume: Int
+        get() = agent.fuelVolume
+    override val resourceType: Resource.ResourceType
+        get() = agent.resourceType
+    override val isCarryingResource: Boolean
+        get() = agent.isCarryingResource
+
+    override fun hasFuel(): Boolean = agent.hasFuel()
+    override fun isCarryingResource(type: Resource.ResourceType): Boolean = agent.isCarryingResource(type)
+    override fun isTouchingResource(type: Resource.ResourceType): Boolean = agent.isTouchingResource(type)
+    override fun isShifting(): Boolean = agent.isShifting()
+}


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Implement Agent Proxy as manipulation save agent instance.
* Make `adversaryAgent` accessible in the strategy file.
* Implement `turnToAdversaryAgent(beta)` 

### :white_check_mark: Checklist:

- [x] Extended the documentation (if necessary)