### PR TITLE
Fix #43 saved agents calculation

### DIFF
--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Mothership.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Mothership.kt
@@ -288,7 +288,7 @@ class Mothership(id: Int, team: Team, level: AbstractLevel) :
     }
 
     val agentsAtHomePoints: Int
-        get() = ((agentsAtHomePosition * 100) / agentCount)
+        get() = ((agentsAtHomePosition * 100) / strategyAgentCount)
 
     private val agentsAtHomePosition: Int
         get() {


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Fixed saved agents calculation

### :hammer: Breaking Changes

* None

### :white_check_mark: Checklist:

- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the documentation (if necessary)

### :camera_flash: Screenshots

![grafik](https://github.com/openbase/planetsudo.engine/assets/118300318/e3eccfc2-c0c3-4c9f-a9cc-c641d3dd6f6b)
1 of 5 agents is alive at the mothership => 20P