### PR TITLE
Fix #20 Clock displays wrong time

### DIFF
--- a/src/main/kotlin/org/openbase/planetsudo/game/GameManager.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/GameManager.kt
@@ -204,7 +204,7 @@ class GameManager : Runnable {
 
         const val DEFAULT_GAME_SPEED_FACTOR: Int = 1
 
-        const val MIN_GAME_SPEED_FACTOR: Double = 0.01
+        const val MIN_GAME_SPEED_FACTOR: Double = 0.00
         const val MAX_GAME_SPEED_FACTOR: Double = 100.0
 
         @JvmStatic

--- a/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
@@ -20,7 +20,7 @@ import javax.swing.*
  */
 class LevelMenuPanel : JPanel(), ActionListener {
     private var minutes: Int
-    private var secunds: Int
+    private var seconds: Int
     private val timer: Timer
     private var levelName: String
 
@@ -32,14 +32,14 @@ class LevelMenuPanel : JPanel(), ActionListener {
     private var text: String? = null
     private fun updateTitle() {
         text = "$levelName ["
-        if (minutes < 9) {
+        if (minutes <= 9) {
             text += "0"
         }
         text += "$minutes:"
-        if (secunds < 9) {
+        if (seconds <= 9) {
             text += "0"
         }
-        text += "$secunds]"
+        text += "$seconds]"
         nameAndTimeLabel!!.text = text
     }
 
@@ -55,7 +55,7 @@ class LevelMenuPanel : JPanel(), ActionListener {
 
     fun reset() {
         stopTimer()
-        secunds = 0
+        seconds = 0
         minutes = 0
     }
 
@@ -102,18 +102,18 @@ class LevelMenuPanel : JPanel(), ActionListener {
     init {
         initComponents()
         this.minutes = 0
-        this.secunds = 0
+        this.seconds = 0
         this.levelName = "Level"
         this.timer = Timer(1000, this)
     }
 
     // End of variables declaration//GEN-END:variables
     override fun actionPerformed(ex: ActionEvent) {
-        if (secunds >= 60) {
-            minutes++
-            secunds = 0
+        if (seconds < 59) {
+            seconds++
         } else {
-            secunds++
+            minutes++
+            seconds = 0
         }
         updateTitle()
     }

--- a/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
@@ -12,7 +12,6 @@ package org.openbase.planetsudo.view.menu
 import org.openbase.planetsudo.level.AbstractLevel
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
-import java.beans.PropertyChangeListener
 import javax.swing.*
 
 /**

--- a/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/menu/LevelMenuPanel.kt
@@ -12,6 +12,7 @@ package org.openbase.planetsudo.view.menu
 import org.openbase.planetsudo.level.AbstractLevel
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
+import java.beans.PropertyChangeListener
 import javax.swing.*
 
 /**
@@ -26,6 +27,14 @@ class LevelMenuPanel : JPanel(), ActionListener {
 
     fun setLevel(level: AbstractLevel) {
         levelName = level.name
+        level.addPropertyChangeListener {
+            if (it.propertyName == AbstractLevel.GAME_SPEED_FACTOR_CHANGED) {
+                timer.isRunning.let { running ->
+                    timer.delay = (1000.0 * (1 / (it.newValue as Double))).toInt()
+                    if (running) timer.restart()
+                }
+            }
+        }
         updateTitle()
     }
 


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Fixed off-by-one error on padding seconds 0-9 with a leading '0'
* Fixed one minute having 61 seconds due to displaying 00:60

### :white_check_mark: Checklist:

- [ ] High priority
- [ ] Efficient code
- [x] Mildly annoying
- [x] Took less than 10 minutes

### :camera_flash: Screenshots

Screenshots to review the UX/UI Design:
![grafik](https://github.com/openbase/planetsudo.engine/assets/118300318/41dc6cc3-9c16-4f2b-9576-820e22f41600)
