### PR TITLE
Agents got killed before collision while shifting

### DIFF
--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
@@ -315,8 +315,8 @@ class Agent(
             // shift
             if (isShifting) {
                 (0..SHIFT_EXTRA_SPEED).forEach { _ ->
-                    if (isCollisionDetected) {
-                        kill()
+                    if (isCollisionDetected) { // Will collide with wall?
+                        return@performAction
                     }
                     if (consumeTonicForShifting()) {
                         // move and apply new direction


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Closes #65 
* Agents no longer die when running into a wall while shifting 
  * Agents used to check once and move thrice, then hit a wall and die
* Now they just stop for this turn before they encounter a wall

### :hammer: Breaking Changes

* None

### :white_check_mark: Checklist:

- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the documentation (if necessary)

### :camera_flash: Screenshots
* None

### :question: How to test
1. Create new strategy
2. Add basic rules for tonic and shifting
3. Run many fights using the strategy
4. Hopefully no agents die by shifting into a wall
