### PR TITLE
Feature/67 make map size available for strategy

### DIFF
--- a/src/main/kotlin/org/openbase/planetsudo/game/strategy/AbstractStrategy.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/strategy/AbstractStrategy.kt
@@ -29,6 +29,8 @@ abstract class AbstractStrategy<LEVEL : GlobalAgentInterface<*>>(val agent: Agen
 
     private val strategyOwner: Agent by lazy { agent as Agent }
     val mothership: MothershipInterface by lazy { strategyOwner.mothership }
+
+    val tower: TowerInterface by lazy { strategyOwner.mothership.tower }
     val enemyAgent get() = strategyOwner.enemyAgent
     val teamAgent get() = strategyOwner.teamAgent
     private val mothershipInternal: Mothership by lazy { strategyOwner.mothership }

--- a/src/main/kotlin/org/openbase/planetsudo/game/strategy/DivineStrategy.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/strategy/DivineStrategy.kt
@@ -64,7 +64,7 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
         // -------------------------------------------->
         "See Resources" swat SwatTeam.NOT_COMMANDER inCase {
             agent.seeResource &&
-                    (agent.isTonicAtLimit && agent.seeResource(ResourceType.Tonic)).not()
+                (agent.isTonicAtLimit && agent.seeResource(ResourceType.Tonic)).not()
         } then {
             agent.goToResource()
         }
@@ -110,10 +110,10 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
             object : Rule("PickUp") {
                 override fun constraint(): Boolean {
                     return !agent.isCommander && (
-                            agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
-                                ResourceType.ExtraMothershipFuel,
-                            )
-                            )
+                        agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
+                            ResourceType.ExtraMothershipFuel,
+                        )
+                        )
                 }
 
                 override fun action() {
@@ -141,10 +141,10 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
             object : Rule("PickUp and Place") {
                 override fun constraint(): Boolean {
                     return agent.isCommander && (
-                            agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
-                                ResourceType.ExtraMothershipFuel,
-                            )
-                            ) && !mothership.isMarkerDeployed && !agent.seeMarker()
+                        agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
+                            ResourceType.ExtraMothershipFuel,
+                        )
+                        ) && !mothership.isMarkerDeployed && !agent.seeMarker()
                 }
 
                 override fun action() {

--- a/src/main/kotlin/org/openbase/planetsudo/game/strategy/DivineStrategy.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/game/strategy/DivineStrategy.kt
@@ -1,6 +1,7 @@
 package org.openbase.planetsudo.game.strategy
 
 import org.openbase.planetsudo.game.SwatTeam
+import org.openbase.planetsudo.level.LevelSize
 import org.openbase.planetsudo.level.levelobjects.AgentInterface
 import org.openbase.planetsudo.level.levelobjects.Resource.ResourceType
 import org.openbase.planetsudo.level.levelobjects.Tower
@@ -37,18 +38,17 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
                 }
             },
         )
-        // -------------------------------------------->
-        createRule(
-            object : Rule("Discover", SwatTeam.COMMANDER) {
-                override fun constraint(): Boolean {
-                    return true
-                }
 
-                override fun action() {
-                    agent.goRight(4)
-                }
-            },
-        )
+        "Discover" commander inCase { true } then { agent.goRight(4) }
+
+        "Scan" commander inCase { tower.type == Tower.TowerType.ObservationTower && tower.levelSize == LevelSize.UNKNOWN } then {
+            tower.scanLevelSize()
+        }
+
+        "Place Observation Tower" commander inCase { agent.hasTower } then {
+            agent.constructTower(Tower.TowerType.ObservationTower)
+        }
+
         // -------------------------------------------->
 //        createRule(
 //            object : Rule("Avoid Agents", SwatTeam.COMMANDER) {
@@ -64,7 +64,7 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
         // -------------------------------------------->
         "See Resources" swat SwatTeam.NOT_COMMANDER inCase {
             agent.seeResource &&
-                (agent.isTonicAtLimit && agent.seeResource(ResourceType.Tonic)).not()
+                    (agent.isTonicAtLimit && agent.seeResource(ResourceType.Tonic)).not()
         } then {
             agent.goToResource()
         }
@@ -110,10 +110,10 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
             object : Rule("PickUp") {
                 override fun constraint(): Boolean {
                     return !agent.isCommander && (
-                        agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
-                            ResourceType.ExtraMothershipFuel,
-                        )
-                        )
+                            agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
+                                ResourceType.ExtraMothershipFuel,
+                            )
+                            )
                 }
 
                 override fun action() {
@@ -141,10 +141,10 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
             object : Rule("PickUp and Place") {
                 override fun constraint(): Boolean {
                     return agent.isCommander && (
-                        agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
-                            ResourceType.ExtraMothershipFuel,
-                        )
-                        ) && !mothership.isMarkerDeployed && !agent.seeMarker()
+                            agent.isTouchingResource(ResourceType.DoublePoints) || agent.isTouchingResource(
+                                ResourceType.ExtraMothershipFuel,
+                            )
+                            ) && !mothership.isMarkerDeployed && !agent.seeMarker()
                 }
 
                 override fun action() {
@@ -498,19 +498,6 @@ class DivineStrategy(agent: AgentInterface) : StrategyLevelLegacy(agent) {
                 }
             },
         )
-        // -------------------------------------------->
-        createRule(
-            object : Rule("Construct Tower", SwatTeam.COMMANDER) {
-                override fun constraint(): Boolean {
-                    return agent.hasTower && agent.seeResource
-                }
-
-                override fun action() {
-                    agent.constructTower(Tower.TowerType.DefenceTower)
-                }
-            },
-        )
-        // -------------------------------------------->
         createRule(
             object : Rule("Follow Wall", SwatTeam.ALPHA) {
                 override fun constraint(): Boolean {

--- a/src/main/kotlin/org/openbase/planetsudo/level/AbstractLevel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/AbstractLevel.kt
@@ -33,6 +33,7 @@ abstract class AbstractLevel : AbstractGameObject, Runnable {
     private val RESOURCES_LOCK: Any = SyncObject("ResourcesLock")
     private val TOWER_LOCK: Any = SyncObject("TowerLock")
     private val base: Point2D
+    val size: LevelSize by lazy { LevelSize.fromLevel(this) }
 
     @JvmField
     val levelBorderPolygon: Polygon
@@ -102,11 +103,11 @@ abstract class AbstractLevel : AbstractGameObject, Runnable {
         this.base = calculateBasePosition(levelBorderPolygon)
 
         levelBorderPolygon.translate(-base.x.toInt(), -base.y.toInt())
-        if (levelWallPolygons != null) {
-            for (p in levelWallPolygons) {
-                p.translate(-base.x.toInt(), -base.y.toInt())
-            }
+
+        for (p in levelWallPolygons) {
+            p.translate(-base.x.toInt(), -base.y.toInt())
         }
+
         for (homepos in homePositions) {
             homepos.translateIntoBase(base)
         }

--- a/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
@@ -6,7 +6,7 @@ enum class LevelSize(val label: String) {
     SMALL("Klein"),
     MEDIUM("Mittel"),
     LARGE("Groß"),
-
+    UNKNOWN("?"),
     ;
 
     companion object {

--- a/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
@@ -1,0 +1,22 @@
+package org.openbase.planetsudo.level
+
+import kotlin.math.max
+
+enum class LevelSize(val label: String) {
+    SMALL("Klein"),
+    MEDIUM("Mittel"),
+    LARGE("Groß"),
+    
+    ;
+
+    companion object {
+        fun fromLevel(level: AbstractLevel): LevelSize {
+            val size = max(level.levelBorderPolygon.bounds2D.width, level.levelBorderPolygon.bounds2D.height)
+            return when {
+                size <= 1000 -> SMALL
+                size <= 1500 -> MEDIUM
+                else -> LARGE
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/LevelSize.kt
@@ -6,7 +6,7 @@ enum class LevelSize(val label: String) {
     SMALL("Klein"),
     MEDIUM("Mittel"),
     LARGE("Groß"),
-    
+
     ;
 
     companion object {

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
@@ -667,7 +667,7 @@ class Agent(
                     direction.turnTo(position, teamAgent.position)
                     ap.getActionPoint(value * 2)
                     teamAgent.spendFuel(useFuel(value)).also {
-                            // charge leftover back to origin
+                        // charge leftover back to origin
                             leftover ->
                         spendFuel(leftover)
                     }
@@ -814,7 +814,6 @@ class Agent(
 
     override fun seeMarker(): Boolean = mothership.teamMarker.seeMarker(this)
 
-    @Suppress("OVERRIDE_DEPRECATION")
     override fun seeTower(): Boolean = mothership.tower.seeTower(this)
 
     @Suppress("OVERRIDE_DEPRECATION")

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Agent.kt
@@ -667,7 +667,7 @@ class Agent(
                     direction.turnTo(position, teamAgent.position)
                     ap.getActionPoint(value * 2)
                     teamAgent.spendFuel(useFuel(value)).also {
-                        // charge leftover back to origin
+                            // charge leftover back to origin
                             leftover ->
                         spendFuel(leftover)
                     }

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentLegacyInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/AgentLegacyInterface.kt
@@ -9,7 +9,6 @@ interface AgentLegacyInterface : AgentSpecialInterface<AgentSpecialInterfaceGerm
      *
      * @return true oder false
      */
-    @Deprecated("NOT YET SUPPORTED")
     fun seeTower(): Boolean
 
     /**
@@ -17,7 +16,6 @@ interface AgentLegacyInterface : AgentSpecialInterface<AgentSpecialInterfaceGerm
      * Bedenke das nur Commander einen Turm trägt!
      * @return
      */
-    @Deprecated("NOT YET SUPPORTED")
     val hasTower: Boolean
 
     /**
@@ -30,14 +28,12 @@ interface AgentLegacyInterface : AgentSpecialInterface<AgentSpecialInterfaceGerm
      *
      * @param type Hier rüber kannst du den Turmtypen auswählen welcher errichtet werden soll.
      */
-    @Deprecated("NOT YET SUPPORTED")
     fun constructTower(type: Tower.TowerType)
 
     /**
      * Baut einen Turm wieder ab der zuvor aufgestellt wurde.
      * Diese Aktion kann nur vom Commander durchgeführt werden, und zwar nur dann, wenn er in unmittelbarer Nähe des Turms ist.
      */
-    @Deprecated("NOT YET SUPPORTED")
     fun deconstructTower()
 
     /**

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
@@ -9,6 +9,7 @@ import org.openbase.planetsudo.game.GameSound
 import org.openbase.planetsudo.geometry.Direction2D
 import org.openbase.planetsudo.geometry.Point2D
 import org.openbase.planetsudo.level.AbstractLevel
+import org.openbase.planetsudo.level.LevelSize
 import org.openbase.planetsudo.level.ResourcePlacement
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -45,6 +46,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     private val condition = lock.newCondition()
     private val placement: ResourcePlacement? = null
     private val timer: Timer
+    private var levelSize: LevelSize = LevelSize.UNKNOWN
 
     var shieldForce: Int = 0
         private set
@@ -56,6 +58,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     val isAttacked: Boolean = false
     var isConstructed: Boolean = false
         private set
+
 
     init {
         this.position = Point2D()
@@ -187,6 +190,14 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         }
     }
 
+    fun scanLevelSize() {
+        if (!isConstructed) {
+            return
+        }
+        levelSize = level.size
+        changes.firePropertyChange(TOWER_SCAN_LEVEL, null, null)
+    }
+
     val isBurning: Boolean
         get() = shieldForce < Mothership.BURNING_TOWER && hasFuel()
 
@@ -210,6 +221,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         const val TOWER_FUEL_VOLUME: Int = 500
         const val TOWER_FUEL_STATE_CHANGE: String = "FuelStateChange"
         const val TOWER_SHIELD_STATE_CHANGE: String = "ShieldStateChange"
+        const val TOWER_SCAN_LEVEL: String = "ScanLevel"
         const val TOWER_CONSTRUCT: String = "construct tower"
         const val TOWER_DECONSTRUCT: String = "deconstruct tower"
 

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
@@ -200,7 +200,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     }
 
     override fun scanLevelSize() {
-        if (!isConstructed) {
+        if (!isConstructed || levelSize != LevelSize.UNKNOWN) {
             return
         }
         levelSize = level.size

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
@@ -35,30 +35,39 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         SIZE.toDouble(),
         ObjectShape.Rec,
     ),
-    ActionListener {
+    ActionListener,
+    TowerInterface {
     enum class TowerType {
-        DefenceTower, ObservationTower
+        Unknown, DefenceTower, ObservationTower
     }
 
-    var type: TowerType? = null
+    override var type: TowerType = TowerType.Unknown
         private set
+
     private val lock = ReentrantLock()
     private val condition = lock.newCondition()
     private val placement: ResourcePlacement? = null
     private val timer: Timer
-    private var levelSize: LevelSize = LevelSize.UNKNOWN
+
+    override var levelSize: LevelSize = LevelSize.UNKNOWN
 
     var shieldForce: Int = 0
         private set
-    var fuel: Int = 0
+
+    override var fuel: Int = 0
         private set
+
+    override val fuelVolume: Int
+        get() = TOWER_FUEL_VOLUME
+
+    override val fuelInPercent: Int
+        get() = (fuel * 100) / fuelVolume
 
     @JvmField
     val direction: Direction2D = Direction2D(0)
     val isAttacked: Boolean = false
     var isConstructed: Boolean = false
         private set
-
 
     init {
         this.position = Point2D()
@@ -73,7 +82,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
                         Thread.sleep(1000)
                         continue
                     }
-                    direction.angle = direction.angle + 10
+                    direction.angle += 10
                     Thread.sleep(100)
                 }
             } catch (ex: InterruptedException) {
@@ -85,7 +94,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     }
 
     @Throws(CouldNotPerformException::class)
-    fun construct(type: TowerType?, commander: Agent) {
+    fun construct(type: TowerType, commander: Agent) {
         if (!commander.isCommander) {
             commander.kill()
             throw CouldNotPerformException("Only the commander can construct a tower!")
@@ -117,7 +126,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         isConstructed = false
     }
 
-    fun seeTower(agent: Agent): Boolean {
+    override fun seeTower(agent: Agent): Boolean {
         if (!isConstructed) {
             return false
         }
@@ -125,12 +134,12 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         return bounds.intersects(agent.bounds)
     }
 
-    fun orderFuel(fuel: Int, agent: Agent?): Int {
+    override fun orderFuel(fuel: Int, agent: Agent?): Int {
         var fuel = fuel
         if (agent == null || bounds.contains(agent.bounds)) {
             try {
                 val oldFuel = this.fuel
-                if (fuel <= 0) { // fuel emty
+                if (fuel <= 0) { // fuel empty
                     fuel = 0
                 } else if (this.fuel < fuel) { // use last fuel
                     fuel = this.fuel
@@ -151,7 +160,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         return fuel
     }
 
-    fun hasFuel(): Boolean {
+    override fun hasFuel(): Boolean {
         return fuel > 0
     }
 
@@ -165,7 +174,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     }
 
     @Synchronized
-    fun attack() {
+    override fun attack() {
         logger.debug("Attack Mothership")
         if (shieldForce > 0) {
             shieldForce--
@@ -180,7 +189,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
     }
 
     @Synchronized
-    fun repair() {
+    override fun repair() {
         if (shieldForce < 100) {
             shieldForce++
             if (shieldForce > Mothership.Companion.BURNING_TOWER && timer.isRunning) {
@@ -190,7 +199,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         }
     }
 
-    fun scanLevelSize() {
+    override fun scanLevelSize() {
         if (!isConstructed) {
             return
         }
@@ -198,16 +207,16 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         changes.firePropertyChange(TOWER_SCAN_LEVEL, null, null)
     }
 
-    val isBurning: Boolean
+    override val isBurning: Boolean
         get() = shieldForce < Mothership.BURNING_TOWER && hasFuel()
 
-    val shieldPoints: Int
+    override val shieldPoints: Int
         get() = shieldForce / 2
 
-    val isMaxDamaged: Boolean
+    override val isMaxDamaged: Boolean
         get() = shieldForce == 0
 
-    val isDamaged: Boolean
+    override val isDamaged: Boolean
         get() = shieldForce < 100
 
     override fun actionPerformed(ex: ActionEvent) {

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/Tower.kt
@@ -126,7 +126,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         isConstructed = false
     }
 
-    override fun seeTower(agent: Agent): Boolean {
+    fun seeTower(agent: Agent): Boolean {
         if (!isConstructed) {
             return false
         }
@@ -134,7 +134,7 @@ class Tower(id: Int, level: AbstractLevel, @JvmField val mothership: Mothership)
         return bounds.intersects(agent.bounds)
     }
 
-    override fun orderFuel(fuel: Int, agent: Agent?): Int {
+    fun orderFuel(fuel: Int, agent: Agent?): Int {
         var fuel = fuel
         if (agent == null || bounds.contains(agent.bounds)) {
             try {

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterface.kt
@@ -32,16 +32,6 @@ interface TowerInterface {
     val de get() = TowerInterfaceGermanWrapper(this)
 
     /**
-     * Checks whether the given agent can see the tower.
-     */
-    fun seeTower(agent: Agent): Boolean
-
-    /**
-     * Orders fuel from the tower. Returns the amount actually provided.
-     */
-    fun orderFuel(fuel: Int, agent: Agent?): Int
-
-    /**
      * Returns whether the tower has any fuel left.
      */
     fun hasFuel(): Boolean

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterface.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterface.kt
@@ -1,0 +1,108 @@
+package org.openbase.planetsudo.level.levelobjects
+
+import org.openbase.planetsudo.level.LevelSize
+
+/*-
+ * #%L
+ * PlanetSudo GameEngine
+ * %%
+ * Copyright (C) 2009 - 2024 openbase.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+/**
+ *
+ * @author Divine Threepwood
+ */
+interface TowerInterface {
+
+    val de get() = TowerInterfaceGermanWrapper(this)
+
+    /**
+     * Checks whether the given agent can see the tower.
+     */
+    fun seeTower(agent: Agent): Boolean
+
+    /**
+     * Orders fuel from the tower. Returns the amount actually provided.
+     */
+    fun orderFuel(fuel: Int, agent: Agent?): Int
+
+    /**
+     * Returns whether the tower has any fuel left.
+     */
+    fun hasFuel(): Boolean
+
+    /**
+     * Current fuel amount of the tower.
+     */
+    val fuel: Int
+
+    /**
+     * Maximum fuel capacity of the tower.
+     */
+    val fuelVolume: Int
+
+    /**
+     * Current fuel level as percentage.
+     */
+    val fuelInPercent: Int
+
+    /**
+     * Makes the tower perform an attack.
+     */
+    fun attack()
+
+    /**
+     * Repairs the tower (increases shield strength).
+     */
+    fun repair()
+
+    /**
+     * Returns whether the tower is burning (losing fuel).
+     */
+    val isBurning: Boolean
+
+    /**
+     * Shield points of the tower.
+     */
+    val shieldPoints: Int
+
+    /**
+     * Returns whether the tower is completely destroyed (no shield left).
+     */
+    val isMaxDamaged: Boolean
+
+    /**
+     * Returns whether the tower is damaged (shield not full).
+     */
+    val isDamaged: Boolean
+
+    /**
+     * Current tower type (DefenceTower or ObservationTower). Unknown if no tower is constructed.
+     */
+    val type: Tower.TowerType
+
+    /**
+     * Scans and updates the currently detected level size.
+     */
+    fun scanLevelSize()
+
+    /**
+     * The last scanned level size.
+     */
+    val levelSize: LevelSize
+}

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterfaceGermanWrapper.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterfaceGermanWrapper.kt
@@ -28,16 +28,6 @@ package org.openbase.planetsudo.level.levelobjects
 class TowerInterfaceGermanWrapper(private val tower: TowerInterface) {
 
     /**
-     * Prüft ob der Agent den Turm sehen kann.
-     */
-    fun siehtTurm(agent: Agent) = tower.seeTower(agent)
-
-    /**
-     * Bestellt Treibstoff vom Turm.
-     */
-    fun bestelleTreibstoff(menge: Int, agent: Agent?) = tower.orderFuel(menge, agent)
-
-    /**
      * Gibt zurück, ob der Turm Treibstoff hat.
      */
     fun hatTreibstoff() = tower.hasFuel()

--- a/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterfaceGermanWrapper.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/level/levelobjects/TowerInterfaceGermanWrapper.kt
@@ -1,0 +1,104 @@
+package org.openbase.planetsudo.level.levelobjects
+
+/*-
+ * #%L
+ * PlanetSudo GameEngine
+ * %%
+ * Copyright (C) 2009 - 2024 openbase.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+/**
+ *
+ * @author Divine Threepwood
+ */
+class TowerInterfaceGermanWrapper(private val tower: TowerInterface) {
+
+    /**
+     * Prüft ob der Agent den Turm sehen kann.
+     */
+    fun siehtTurm(agent: Agent) = tower.seeTower(agent)
+
+    /**
+     * Bestellt Treibstoff vom Turm.
+     */
+    fun bestelleTreibstoff(menge: Int, agent: Agent?) = tower.orderFuel(menge, agent)
+
+    /**
+     * Gibt zurück, ob der Turm Treibstoff hat.
+     */
+    fun hatTreibstoff() = tower.hasFuel()
+
+    /**
+     * Aktueller Treibstoff des Turms.
+     */
+    val treibstoff get() = tower.fuel
+
+    /**
+     * Maximales Treibstoffvolumen des Turms.
+     */
+    val treibstoffVolumen get() = tower.fuelVolume
+
+    /**
+     * Treibstoff in Prozent.
+     */
+    val treibstoffInProzent get() = tower.fuelInPercent
+
+    /**
+     * Lässt den Turm angreifen.
+     */
+    fun greifeAn() = tower.attack()
+
+    /**
+     * Repariert den Turm.
+     */
+    fun repariere() = tower.repair()
+
+    /**
+     * Gibt zurück, ob der Turm brennt.
+     */
+    val istAmBrennen get() = tower.isBurning
+
+    /**
+     * Gibt die Schildpunkte des Turms zurück.
+     */
+    val schildPunkte get() = tower.shieldPoints
+
+    /**
+     * Gibt zurück, ob der Turm maximal beschädigt ist.
+     */
+    val istMaximalBeschaedigt get() = tower.isMaxDamaged
+
+    /**
+     * Gibt zurück, ob der Turm beschädigt ist.
+     */
+    val istBeschaedigt get() = tower.isDamaged
+
+    /**
+     * Scannt die Level-Größe und aktualisiert die interne Größe.
+     */
+    fun scanneLevelGroesse() = tower.scanLevelSize()
+
+    /**
+     * Zuletzt gescannte Level-Größe.
+     */
+    val levelGroesse get() = tower.levelSize
+
+    /**
+     * Typ des Turms (DefenceTower oder ObservationTower). Null wenn nicht konstruiert.
+     */
+    val turmTyp get() = tower.type
+}

--- a/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.form
+++ b/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.form
@@ -53,7 +53,7 @@
       <Properties>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-            <TitledBorder title="Vorschau"/>
+            <TitledBorder title="Vorschau2"/>
           </Border>
         </Property>
       </Properties>

--- a/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.form
+++ b/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.form
@@ -53,7 +53,7 @@
       <Properties>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-            <TitledBorder title="Vorschau2"/>
+            <TitledBorder title="Vorschau"/>
           </Border>
         </Property>
       </Properties>

--- a/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/configuration/ConfigurationPanel.kt
@@ -695,6 +695,8 @@ class ConfigurationPanel : JPanel() {
             }
             val level = getInstance()!!.loadLevel(levelName)
             gameManager.setLevel(level!!)
+            levelPreviewPanel!!.border =
+                BorderFactory.createTitledBorder("Nächstes Level: ${level.name} \tGröße: ${level.size.label}")
             levelPreviewDisplayPanel!!.setLevel(level)
             levelPreviewDisplayPanel!!.isOpaque = true
             levelPreviewDisplayPanel!!.background = level.color

--- a/src/main/kotlin/org/openbase/planetsudo/view/level/LevelDisplayPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/level/LevelDisplayPanel.kt
@@ -14,6 +14,7 @@ import org.openbase.planetsudo.level.AbstractLevel
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import javax.swing.GroupLayout
+import javax.swing.JLabel
 
 /**
  *
@@ -40,6 +41,8 @@ class LevelDisplayPanel : ResourceDisplayPanel<LevelPanel>(), Runnable {
     fun setLevel(level: AbstractLevel) {
         setVisibleResourcePanel(LevelPanel(level, this))
     }
+
+    private val level get() = visibleResourcePanel?.resource
 
     fun displayLevelObjects() {
         if (visibleResourcePanel != null) {
@@ -89,6 +92,9 @@ class LevelDisplayPanel : ResourceDisplayPanel<LevelPanel>(), Runnable {
             layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                 .addGap(0, 300, Short.MAX_VALUE.toInt()),
         )
+        level?.let {
+            parent.add("Label", JLabel("Name: ${level?.name} (${level?.size}) }"))
+        }
     } // </editor-fold>//GEN-END:initComponents
 
     override fun run() {

--- a/src/main/kotlin/org/openbase/planetsudo/view/level/levelobjects/TowerTopPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/level/levelobjects/TowerTopPanel.kt
@@ -79,35 +79,37 @@ class TowerTopPanel(tower: Tower, parentPanel: TowerPanel) :
         direction = resource.direction
 
         gg2 = g2.create() as Graphics2D
-        paintImageRotated(tower.direction, gg2!!)
+        try {
+            paintImageRotated(tower.direction, gg2!!)
 
-        // draw scanning waves if active
-        if (scanning) {
-            try {
+            // draw scanning waves if active
+            if (scanning) {
                 val overlay = g2.create() as Graphics2D
-                overlay.composite = java.awt.AlphaComposite.getInstance(java.awt.AlphaComposite.SRC_OVER, 1.0f)
-                overlay.stroke = BasicStroke(3.0f)
+                try {
+                    overlay.composite = java.awt.AlphaComposite.getInstance(java.awt.AlphaComposite.SRC_OVER, 1.0f)
+                    overlay.stroke = BasicStroke(3.0f)
 
-                val cx = boundingBox.centerX
-                val cy = boundingBox.centerY
+                    val cx = boundingBox.centerX
+                    val cy = boundingBox.centerY
 
-                for (r in scanRings) {
-                    if (r <= 0) continue
-                    val progress = (r / scanMaxRadius).coerceIn(0.0, 1.0)
-                    val alpha = (1.0 - progress) * 0.7
-                    val color = Color(0, 220, 255, (alpha * 255).toInt().coerceIn(0, 255))
-                    overlay.color = color
-                    val ir = r
-                    overlay.draw(Arc2D.Double(cx - ir, cy - ir, ir * 2, ir * 2, 0.0, 360.0, Arc2D.OPEN))
+                    for (r in scanRings) {
+                        if (r <= 0) continue
+                        val progress = (r / scanMaxRadius).coerceIn(0.0, 1.0)
+                        val alpha = (1.0 - progress) * 0.7
+                        val color = Color(0, 220, 255, (alpha * 255).toInt().coerceIn(0, 255))
+                        overlay.color = color
+                        val ir = r
+                        overlay.draw(Arc2D.Double(cx - ir, cy - ir, ir * 2, ir * 2, 0.0, 360.0, Arc2D.OPEN))
+                    }
+                } catch (ex: Exception) {
+                    // ignore painting errors
+                } finally {
+                    overlay.dispose()
                 }
-
-                overlay.dispose()
-            } catch (ex: Exception) {
-                // ignore painting errors
             }
+        } finally {
+            gg2?.dispose()
         }
-
-        gg2!!.dispose()
     }
 
     override fun propertyChange(evt: PropertyChangeEvent) {

--- a/src/main/kotlin/org/openbase/planetsudo/view/level/levelobjects/TowerTopPanel.kt
+++ b/src/main/kotlin/org/openbase/planetsudo/view/level/levelobjects/TowerTopPanel.kt
@@ -6,10 +6,14 @@ import org.openbase.planetsudo.level.levelobjects.Tower
 import org.openbase.planetsudo.level.levelobjects.Tower.TowerType
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.awt.BasicStroke
+import java.awt.Color
 import java.awt.Graphics2D
 import java.awt.event.MouseEvent
+import java.awt.geom.Arc2D
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
+import javax.swing.Timer
 
 /**
  *
@@ -29,10 +33,40 @@ class TowerTopPanel(tower: Tower, parentPanel: TowerPanel) :
     private var gg2: Graphics2D? = null
     private var direction: Direction2D? = null
 
+    // scanning animation state: expanding wave rings
+    private var scanning: Boolean = false
+    private val scanRings: MutableList<Double> = ArrayList()
+    private var scanTimer: Timer? = null
+    private var scanMaxRadius: Double = 0.0
+    private val ringSpeed: Double = 12.0 // pixels per tick
+    private val ringSpacing: Double = 40.0 // spacing between consecutive rings
+
     init {
         LOGGER.info("Create $this")
         this.tower = tower
         tower.addPropertyChangeListener(this)
+
+        // Timer advances rings outward
+        scanTimer = Timer(40) {
+            if (!scanning) return@Timer
+            val it = scanRings.listIterator()
+            while (it.hasNext()) {
+                val idx = it.nextIndex()
+                val v = it.next()
+                val nv = v + ringSpeed
+                it.set(nv)
+                // remove ring if beyond max radius + spacing
+                if (nv > scanMaxRadius + ringSpacing * 2) {
+                    it.remove()
+                }
+            }
+            // stop when no rings left
+            if (scanRings.isEmpty()) {
+                scanning = false
+                scanTimer?.stop()
+            }
+            parentPanel.repaint()
+        }
     }
 
     override fun paintComponent(g2: Graphics2D, gl: Graphics2D) {
@@ -43,17 +77,76 @@ class TowerTopPanel(tower: Tower, parentPanel: TowerPanel) :
 
         boundingBox = resource.bounds
         direction = resource.direction
+
         gg2 = g2.create() as Graphics2D
         paintImageRotated(tower.direction, gg2!!)
+
+        // draw scanning waves if active
+        if (scanning) {
+            try {
+                val overlay = g2.create() as Graphics2D
+                overlay.composite = java.awt.AlphaComposite.getInstance(java.awt.AlphaComposite.SRC_OVER, 1.0f)
+                overlay.stroke = BasicStroke(3.0f)
+
+                val cx = boundingBox.centerX
+                val cy = boundingBox.centerY
+
+                for (r in scanRings) {
+                    if (r <= 0) continue
+                    val progress = (r / scanMaxRadius).coerceIn(0.0, 1.0)
+                    val alpha = (1.0 - progress) * 0.7
+                    val color = Color(0, 220, 255, (alpha * 255).toInt().coerceIn(0, 255))
+                    overlay.color = color
+                    val ir = r
+                    overlay.draw(Arc2D.Double(cx - ir, cy - ir, ir * 2, ir * 2, 0.0, 360.0, Arc2D.OPEN))
+                }
+
+                overlay.dispose()
+            } catch (ex: Exception) {
+                // ignore painting errors
+            }
+        }
+
         gg2!!.dispose()
     }
 
     override fun propertyChange(evt: PropertyChangeEvent) {
-//        if (evt.getPropertyName().equals(Tower.REMOVE_TOWER)) {
-//            if (((Tower) evt.getNewValue()).equals(resource)) {
-//                parentResourcePanel.removeChild(this);
-//            }
-//        }
+        //        if (evt.getPropertyName().equals(Tower.REMOVE_TOWER)) {
+        //            if (((Tower) evt.getNewValue()).equals(resource)) {
+        //                parentResourcePanel.removeChild(this);
+        //            }
+        //        }
+        if (evt.propertyName == Tower.TOWER_SCAN_LEVEL) {
+            // start wave animation: compute max radius to level borders
+            val levelBounds = tower.level.levelBorderPolygon.bounds2D
+            val cx = tower.position.x
+            val cy = tower.position.y
+            // compute distance to all 4 corners and take max
+            val corners = arrayOf(
+                doubleArrayOf(levelBounds.minX, levelBounds.minY),
+                doubleArrayOf(levelBounds.minX + levelBounds.width, levelBounds.minY),
+                doubleArrayOf(levelBounds.minX, levelBounds.minY + levelBounds.height),
+                doubleArrayOf(levelBounds.minX + levelBounds.width, levelBounds.minY + levelBounds.height),
+            )
+            var maxd = 0.0
+            for (c in corners) {
+                val dx = c[0] - cx
+                val dy = c[1] - cy
+                val d = Math.hypot(dx, dy)
+                if (d > maxd) maxd = d
+            }
+            scanMaxRadius = maxd
+
+            // prime a few rings so the wave looks continuous
+            scanRings.clear()
+            scanRings.add(0.0)
+            scanRings.add(-ringSpacing)
+            scanRings.add(-ringSpacing * 2)
+            scanning = true
+            scanTimer?.restart()
+            return
+        }
+        // other property changes can be handled here
     }
 
     override val isFocusable: Boolean


### PR DESCRIPTION
### :scroll: Description

Changes proposed in this pull request:
* Introduce level size.
* Implement proper tower interface.
* Make tower available at top level of the strategy.
* Introduce Unknown tower type and make type not nullable.
* Implement scan action and make it available for strategy
* Implement scan animation.

<img width="1330" height="1008" alt="Screenshot 2026-07-07 at 23 58 18" src="https://github.com/user-attachments/assets/54ce7119-08df-4f7d-91c7-2cc7f4ba98c6" />

